### PR TITLE
Open external links in the default web browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const electron = require('electron');
 const app = electron.app;
 const Menu = electron.Menu;
 const BrowserWindow = electron.BrowserWindow;
+const shell = electron.shell;
 
 let mainWindow = null;
 
@@ -54,5 +55,11 @@ app.on('ready', function() {
     mainWindow.on('closed', function() {
         mainWindow = null;
     });
+
+    mainWindow.webContents.on('new-window', function(event, url) {
+        event.preventDefault();
+        shell.openExternal(url);
+    });
+
     mainWindow.show();
 });


### PR DESCRIPTION
Hey, this is just a small improvement to open links in the os' default browser (firefox/chrome/whatever). The default behaviour creates a new electron BrowserWindow which does not share session information etc so i keep getting 404/login pages for things like github/jira etc.

Cheers.